### PR TITLE
fix: Add missing auth.module.ts file

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -1,0 +1,28 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { AuthController } from './auth.controller';
+import { AuthService } from './auth.service';
+import { JwtStrategy } from './strategies/jwt.strategy';
+import { User } from '../database/entities/user.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([User]),
+    PassportModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '1d' }, // Adjust expiration as needed
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+  controllers: [AuthController],
+  providers: [AuthService, JwtStrategy],
+  exports: [AuthService], // Export if other modules need to use AuthService
+})
+export class AuthModule {}


### PR DESCRIPTION
## Problem
The `auth.module.ts` file was missing from the auth module directory, but it was being imported in `app.module.ts`. This would cause the application to fail to start.

## Solution
Added the missing `auth.module.ts` file with proper configuration:
- Imports `TypeOrmModule.forFeature([User])` for User entity repository access
- Configures `JwtModule` asynchronously using `ConfigService` to read `JWT_SECRET` from environment
- Imports `PassportModule` for JWT strategy support
- Declares `AuthController` and provides `AuthService` and `JwtStrategy`
- Exports `AuthService` for potential use in other modules
- fixes #25 

## Testing
- File created and linted successfully
- Module structure follows NestJS best practices
- All dependencies properly configured