### PR TITLE
chore: Update .gitignore to prevent root-level package files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ node_modules/
 .pnp
 .pnp.js
 
+# Root level package files (should only exist in backend/ and frontend/)
+/package.json
+/package-lock.json
+
 # Testing
 coverage/
 *.log


### PR DESCRIPTION
## Description
Update `.gitignore` to prevent root-level package files from being accidentally committed.

## Problem
In a monorepo structure, package files (`package.json`, `package-lock.json`) should only exist in `backend/` and `frontend/` directories. Running `npm install` at the root level can accidentally create these files.

## Solution
Add root-level package file patterns to `.gitignore` to prevent them from being tracked.

## Changes
- Add `/package.json` and `/package-lock.json` to `.gitignore`
- These patterns specifically target root-level files only

## Testing
- Verified no root-level package files exist in the repository
- `.gitignore` patterns will prevent future accidental creation

Fixes #34