### PR TITLE
feat: Backend CORS Configuration

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,6 +31,40 @@
 $ npm install
 ```
 
+## Environment Variables
+
+Create a `.env` file in the backend directory with the following variables:
+
+```env
+# Server
+PORT=3000
+NODE_ENV=development
+
+# Database
+DB_HOST=localhost
+DB_PORT=5432
+DB_USERNAME=postgres
+DB_PASSWORD=postgres
+DB_DATABASE=rara_platform
+
+# JWT
+JWT_SECRET=your-secret-key-here
+
+# CORS Configuration
+FRONTEND_URL=http://localhost:3001
+# For production, use ALLOWED_ORIGINS (comma-separated):
+# ALLOWED_ORIGINS=https://yourdomain.com,https://www.yourdomain.com
+```
+
+### CORS Configuration
+
+The backend is configured to allow CORS requests from the frontend. 
+
+- **Development**: Automatically allows all `localhost` origins
+- **Production**: Use `ALLOWED_ORIGINS` environment variable (comma-separated list)
+- If `FRONTEND_URL` is set, it will be added to allowed origins
+- Credentials (cookies/auth headers) are enabled for authenticated requests
+
 ## Compile and run the project
 
 ```bash

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -5,6 +5,37 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  
+  // CORS Configuration
+  const allowedOrigins = process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(',').map(origin => origin.trim())
+    : [process.env.FRONTEND_URL || 'http://localhost:3001'];
+  
+  app.enableCors({
+    origin: (origin, callback) => {
+      // Allow requests with no origin (like mobile apps, Postman, or curl requests)
+      if (!origin) return callback(null, true);
+      
+      // In development, allow localhost origins
+      if (process.env.NODE_ENV !== 'production') {
+        if (origin.startsWith('http://localhost:') || origin.startsWith('http://127.0.0.1:')) {
+          return callback(null, true);
+        }
+      }
+      
+      // Check if origin is in allowed list
+      if (allowedOrigins.indexOf(origin) !== -1) {
+        callback(null, true);
+      } else {
+        callback(new Error('Not allowed by CORS'));
+      }
+    },
+    credentials: true, // Allow cookies/auth headers
+    methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Requested-With'],
+    exposedHeaders: ['Authorization'],
+  });
+  
   app.useGlobalPipes(new ValidationPipe({
     whitelist: true,
     forbidNonWhitelisted: true,


### PR DESCRIPTION
## Description
Add CORS (Cross-Origin Resource Sharing) configuration to the NestJS backend to allow frontend requests from different origins.

## Problem
Frontend running on `localhost:3001` cannot communicate with backend on `localhost:3000` due to CORS policy blocking cross-origin requests.

## Solution
Configure CORS in NestJS backend with:
- **Development**: Automatically allow all localhost origins
- **Production**: Use environment variables for allowed origins
- Support for credentials (JWT tokens)
- Proper headers and methods configuration

## Changes
- ✅ Added CORS configuration to `backend/src/main.ts`:
  - Environment variable support (`FRONTEND_URL`, `ALLOWED_ORIGINS`)
  - Development mode: automatically allows localhost origins
  - Production mode: uses allowed origins list
  - Credentials enabled for authentication headers
  - Proper HTTP methods and headers configured

- ✅ Updated `backend/README.md`:
  - Added environment variables section
  - Added CORS configuration documentation
  - Examples for development and production

## Environment Variables
- `FRONTEND_URL` - Single frontend URL (development)
- `ALLOWED_ORIGINS` - Comma-separated list of allowed origins (production)

## Technical Details
- Uses NestJS `enableCors()` method
- Dynamic origin checking with callback function
- Supports no-origin requests (mobile apps, Postman)
- Exposes Authorization header for frontend access

## Testing
- No linting errors
- Configuration follows NestJS best practices
- Ready for development and production use

Fixes #41