### PR TITLE
feat(layout): add breadcrumbs navigation component

### DIFF
--- a/frontend/components/layout/breadcrumbs.tsx
+++ b/frontend/components/layout/breadcrumbs.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { ChevronRight, Home } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface BreadcrumbItem {
+  label: string;
+  href: string;
+}
+
+// Map route segments to user-friendly labels
+const routeLabels: Record<string, string> = {
+  dashboard: 'Dashboard',
+  structure: 'Structure',
+  sites: 'Sites',
+  partners: 'Partners',
+  'my-students': 'My Students',
+  'my-sessions': 'My Sessions',
+  availability: 'Availability',
+  profile: 'Profile',
+  settings: 'Settings',
+  'multi-site': 'Multi-Site Operations',
+};
+
+// Generate breadcrumb items from pathname
+function generateBreadcrumbs(pathname: string): BreadcrumbItem[] {
+  // Remove leading and trailing slashes, then split
+  const segments = pathname.split('/').filter(Boolean);
+  
+  const breadcrumbs: BreadcrumbItem[] = [
+    { label: 'Home', href: '/dashboard' },
+  ];
+
+  // Build breadcrumbs from path segments
+  let currentPath = '';
+  segments.forEach((segment, index) => {
+    currentPath += `/${segment}`;
+    
+    // Use custom label if available, otherwise capitalize and replace hyphens
+    const label = routeLabels[segment] || 
+      segment
+        .split('-')
+        .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+        .join(' ');
+    
+    breadcrumbs.push({
+      label,
+      href: currentPath,
+    });
+  });
+
+  return breadcrumbs;
+}
+
+interface BreadcrumbsProps {
+  className?: string;
+  maxItems?: number;
+}
+
+export function Breadcrumbs({ className, maxItems }: BreadcrumbsProps) {
+  const pathname = usePathname();
+  
+  // Don't show breadcrumbs on login/register pages
+  if (pathname === '/login' || pathname === '/register' || pathname === '/') {
+    return null;
+  }
+
+  const breadcrumbs = generateBreadcrumbs(pathname);
+  
+  // Limit the number of breadcrumbs shown if maxItems is specified
+  const displayBreadcrumbs = maxItems && breadcrumbs.length > maxItems
+    ? [
+        breadcrumbs[0], // Always show home
+        { label: '...', href: '#' },
+        ...breadcrumbs.slice(-(maxItems - 2)), // Show last N-2 items
+      ]
+    : breadcrumbs;
+
+  return (
+    <nav
+      aria-label="Breadcrumb"
+      className={cn('flex items-center space-x-2 text-sm text-gray-600', className)}
+    >
+      <ol className="flex items-center space-x-2">
+        {displayBreadcrumbs.map((breadcrumb, index) => {
+          const isLast = index === displayBreadcrumbs.length - 1;
+          const isEllipsis = breadcrumb.label === '...';
+
+          return (
+            <li key={`${breadcrumb.href}-${index}`} className="flex items-center">
+              {index === 0 ? (
+                <Link
+                  href={breadcrumb.href}
+                  className="flex items-center hover:text-gray-900 transition-colors"
+                >
+                  <Home className="h-4 w-4" />
+                  <span className="sr-only">{breadcrumb.label}</span>
+                </Link>
+              ) : (
+                <>
+                  <ChevronRight className="h-4 w-4 text-gray-400 mx-2" />
+                  {isLast ? (
+                    <span className="font-medium text-gray-900" aria-current="page">
+                      {breadcrumb.label}
+                    </span>
+                  ) : isEllipsis ? (
+                    <span className="text-gray-400">...</span>
+                  ) : (
+                    <Link
+                      href={breadcrumb.href}
+                      className="hover:text-gray-900 transition-colors"
+                    >
+                      {breadcrumb.label}
+                    </Link>
+                  )}
+                </>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}

--- a/frontend/components/layout/main-layout.tsx
+++ b/frontend/components/layout/main-layout.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { ReactNode } from 'react';
+import { Breadcrumbs } from './breadcrumbs';
 
 interface MainLayoutProps {
   children: ReactNode;
@@ -18,6 +19,10 @@ export function MainLayout({ children }: MainLayoutProps) {
       <main className="flex-1 flex flex-col min-h-screen">
         <div className="flex-1">
           <div className="max-w-[1920px] mx-auto px-8 py-8">
+            {/* Breadcrumbs Navigation */}
+            <div className="mb-6">
+              <Breadcrumbs />
+            </div>
             {children}
           </div>
         </div>


### PR DESCRIPTION
This PR adds a breadcrumbs navigation component to help users understand their current location in the application and navigate back to parent pages.

## Changes
- Created `Breadcrumbs` component that automatically generates navigation from the current pathname
- Maps route segments to user-friendly labels (e.g., 'my-students' → 'My Students')
- Supports ellipsis truncation for long breadcrumb paths
- Integrated breadcrumbs into `MainLayout`
- Hides breadcrumbs on login/register/home pages
- Includes proper ARIA labels for accessibility

## Features
- Automatic breadcrumb generation from URL pathname
- Custom labels for common routes
- Home icon for root breadcrumb
- Chevron separators between items
- Hover states and smooth transitions
- Current page highlighted (non-clickable)
- Responsive design

Fixes #51