### PR TITLE
feat: Add frontend API client for Sites module

### DIFF
--- a/frontend/lib/api/sites.ts
+++ b/frontend/lib/api/sites.ts
@@ -1,0 +1,69 @@
+import apiClient from '../api-client';
+
+export interface Site {
+  id: string;
+  name: string;
+  address?: string | null;
+  city?: string | null;
+  state?: string | null;
+  zipCode?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateSiteDto {
+  name: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  phone?: string;
+  email?: string;
+  active?: boolean;
+}
+
+export interface UpdateSiteDto {
+  name?: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  phone?: string;
+  email?: string;
+  active?: boolean;
+}
+
+export interface SearchSitesQuery {
+  active?: boolean;
+  city?: string;
+  state?: string;
+}
+
+export const sitesApi = {
+  getAll: async (query?: SearchSitesQuery): Promise<Site[]> => {
+    const response = await apiClient.get<Site[]>('/sites', { params: query });
+    return response.data;
+  },
+
+  getById: async (id: string): Promise<Site> => {
+    const response = await apiClient.get<Site>(`/sites/${id}`);
+    return response.data;
+  },
+
+  create: async (data: CreateSiteDto): Promise<Site> => {
+    const response = await apiClient.post<Site>('/sites', data);
+    return response.data;
+  },
+
+  update: async (id: string, data: UpdateSiteDto): Promise<Site> => {
+    const response = await apiClient.put<Site>(`/sites/${id}`, data);
+    return response.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/sites/${id}`);
+  },
+};


### PR DESCRIPTION
## Description

This PR implements the frontend API client for the Sites module, enabling CRUD operations from the frontend application.

## Changes

- Created `frontend/lib/api/sites.ts` with complete API client implementation
- Added TypeScript interfaces:
  - `Site` - Main site entity interface
  - `CreateSiteDto` - Interface for creating sites
  - `UpdateSiteDto` - Interface for updating sites
  - `SearchSitesQuery` - Interface for filtering sites
- Implemented all CRUD methods:
  - `getAll(query?)` - List sites with optional filters (active, city, state)
  - `getById(id)` - Get single site by ID
  - `create(data)` - Create new site
  - `update(id, data)` - Update existing site
  - `delete(id)` - Delete site

## Implementation Details

- Follows the same pattern as existing `students.ts` and `tutors.ts` API clients
- Uses the shared `apiClient` from `lib/api-client.ts`
- All interfaces match the backend DTOs exactly
- TypeScript types are properly defined
- Code passes linting checks

## Testing

- [x] Code compiles without errors
- [x] Linting passes
- [x] Types match backend DTOs

## Related Issue

Closes #72