### PR TITLE
feat(frontend): add Partners API client with CRUD methods

### DIFF
--- a/frontend/lib/api/partners.ts
+++ b/frontend/lib/api/partners.ts
@@ -1,0 +1,67 @@
+import apiClient from '../api-client';
+
+export type PartnerType = 'School' | 'Co' | 'Organization' | 'Other';
+
+export interface Partner {
+  id: string;
+  name: string;
+  type?: PartnerType | null;
+  contactName?: string | null;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
+  address?: string | null;
+  active: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreatePartnerDto {
+  name: string;
+  type?: PartnerType;
+  contactName?: string;
+  contactEmail?: string;
+  contactPhone?: string;
+  address?: string;
+  active?: boolean;
+}
+
+export interface UpdatePartnerDto {
+  name?: string;
+  type?: PartnerType;
+  contactName?: string;
+  contactEmail?: string;
+  contactPhone?: string;
+  address?: string;
+  active?: boolean;
+}
+
+export interface SearchPartnersQuery {
+  active?: boolean;
+  type?: PartnerType;
+}
+
+export const partnersApi = {
+  getAll: async (query?: SearchPartnersQuery): Promise<Partner[]> => {
+    const response = await apiClient.get<Partner[]>('/partners', { params: query });
+    return response.data;
+  },
+
+  getById: async (id: string): Promise<Partner> => {
+    const response = await apiClient.get<Partner>(`/partners/${id}`);
+    return response.data;
+  },
+
+  create: async (data: CreatePartnerDto): Promise<Partner> => {
+    const response = await apiClient.post<Partner>('/partners', data);
+    return response.data;
+  },
+
+  update: async (id: string, data: UpdatePartnerDto): Promise<Partner> => {
+    const response = await apiClient.put<Partner>(`/partners/${id}`, data);
+    return response.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/partners/${id}`);
+  },
+};


### PR DESCRIPTION
## Description
This PR adds the frontend API client for the Partners module, enabling all CRUD operations from the frontend.

## Changes
- Created `frontend/lib/api/partners.ts` following the same pattern as `sites.ts`
- Added TypeScript interfaces:
  - `Partner` - Main partner interface
  - `CreatePartnerDto` - Interface for creating partners
  - `UpdatePartnerDto` - Interface for updating partners
  - `SearchPartnersQuery` - Interface for search/filter queries
  - `PartnerType` - Type union matching backend enum

- Implemented all CRUD methods:
  - `getAll(query?: SearchPartnersQuery)` - List all partners with optional filters (active, type)
  - `getById(id: string)` - Get partner by ID
  - `create(data: CreatePartnerDto)` - Create new partner
  - `update(id: string, data: UpdatePartnerDto)` - Update existing partner
  - `delete(id: string)` - Delete partner

## Testing
- ✅ No linter errors
- ✅ TypeScript types match backend DTOs
- ✅ Follows existing API client patterns

## Related
Closes #74