### PR TITLE
Fix cookie deletion error and migrate middleware to proxy

### DIFF
--- a/frontend/app/dashboard/page.tsx
+++ b/frontend/app/dashboard/page.tsx
@@ -7,8 +7,9 @@ export default async function DashboardPage() {
   const user = await getServerUser();
   
   // Redirect to login if not authenticated
+  // Add query param to prevent middleware from redirecting back
   if (!user) {
-    redirect('/login');
+    redirect('/login?invalid_token=true');
   }
 
   // Pass user to client component

--- a/frontend/app/proxy.ts
+++ b/frontend/app/proxy.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 
-export function middleware(request: NextRequest) {
+export function proxy(request: NextRequest) {
   const token = request.cookies.get('auth-token')?.value;
   const { pathname } = request.nextUrl;
 
@@ -23,8 +23,20 @@ export function middleware(request: NextRequest) {
   }
 
   // Redirect to dashboard if accessing auth routes with valid token
-  if (isAuthRoute && token) {
+  // BUT: Don't redirect if invalid_token query param is present (prevents redirect loop)
+  const hasInvalidTokenParam = request.nextUrl.searchParams.has('invalid_token');
+  const referer = request.headers.get('referer');
+  const isComingFromDashboard = referer?.includes('/dashboard');
+  
+  if (isAuthRoute && token && !hasInvalidTokenParam && !isComingFromDashboard) {
     return NextResponse.redirect(new URL('/dashboard', request.url));
+  }
+  
+  // If invalid_token param is present, clear the cookie
+  if (hasInvalidTokenParam && token) {
+    const response = NextResponse.next();
+    response.cookies.delete('auth-token');
+    return response;
   }
 
   return NextResponse.next();

--- a/frontend/lib/auth-server.ts
+++ b/frontend/lib/auth-server.ts
@@ -26,8 +26,7 @@ export async function getServerUser(): Promise<User | null> {
     });
 
     if (!response.ok) {
-      // Token is invalid, clear it
-      cookieStore.delete('auth-token');
+      // Token is invalid - return null (cookie will be cleared on client-side or via logout route)
       return null;
     }
 


### PR DESCRIPTION
Fixes #80

## Summary

This PR fixes the cookie deletion error in Server Components and resolves the redirect loop issue, while also migrating to Next.js 16's new proxy convention.

## Changes

- ✅ Removed cookie deletion from `getServerUser()` (cookies can only be modified in Route Handlers/Server Actions)
- ✅ Fixed redirect loop by adding `invalid_token` query parameter check in proxy
- ✅ Migrated `middleware.ts` to `app/proxy.ts` per Next.js 16 conventions
- ✅ Clear invalid cookies when `invalid_token` param is present

## Testing

- [x] Invalid tokens no longer cause cookie deletion errors
- [x] Redirect loop is resolved - users with invalid tokens are properly redirected to login
- [x] Deprecation warning for middleware is resolved
- [x] Valid authentication flow still works correctly