### PR TITLE
feat: Implement DeleteDialog Component

### DIFF
--- a/frontend/components/ui/delete-dialog.tsx
+++ b/frontend/components/ui/delete-dialog.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import * as React from "react"
+import { Loader2 } from "lucide-react"
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+
+export interface DeleteDialogProps {
+  /** Controls dialog visibility */
+  open: boolean
+  /** Callback for state changes */
+  onOpenChange: (open: boolean) => void
+  /** Dialog title (e.g., "Delete Site") */
+  title: string
+  /** Confirmation message (e.g., "Are you sure you want to delete {name}?") */
+  description: string
+  /** Name of item being deleted (for display) */
+  itemName?: string
+  /** Confirm handler */
+  onConfirm: () => void | Promise<void>
+  /** Cancel handler */
+  onCancel: () => void
+  /** Loading state */
+  isLoading?: boolean
+  /** Custom confirm button text (default: "Delete") */
+  confirmLabel?: string
+  /** Custom cancel button text (default: "Cancel") */
+  cancelLabel?: string
+  /** Additional className for SheetContent */
+  className?: string
+}
+
+export function DeleteDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  itemName,
+  onConfirm,
+  onCancel,
+  isLoading = false,
+  confirmLabel = "Delete",
+  cancelLabel = "Cancel",
+  className,
+}: DeleteDialogProps) {
+  const handleConfirm = async () => {
+    await onConfirm()
+  }
+
+  const handleCancel = () => {
+    if (!isLoading) {
+      onCancel()
+    }
+  }
+
+  const handleOpenChange = (newOpen: boolean) => {
+    if (!isLoading) {
+      onOpenChange(newOpen)
+    }
+  }
+
+  // Format description with item name if provided
+  const formattedDescription = itemName
+    ? description.replace(/{name}/g, itemName)
+    : description
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent className={cn("sm:max-w-lg", className)}>
+        <SheetHeader>
+          <SheetTitle>{title}</SheetTitle>
+          <SheetDescription>{formattedDescription}</SheetDescription>
+        </SheetHeader>
+        <SheetFooter className="mt-6">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleCancel}
+            disabled={isLoading}
+          >
+            {cancelLabel}
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isLoading}
+          >
+            {isLoading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                <span>Deleting...</span>
+              </>
+            ) : (
+              confirmLabel
+            )}
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  )
+}


### PR DESCRIPTION
## Description

This PR implements the DeleteDialog component, a reusable confirmation dialog for delete actions.

## Changes

- Created `frontend/components/ui/delete-dialog.tsx`
- Uses Sheet component for dialog structure (consistent with FormDialog)
- Supports item name display with `{name}` placeholder replacement
- Includes loading states with spinner during deletion
- Uses destructive button variant for confirm action
- Prevents dialog closing during loading state

## Implementation Details

The component follows the same patterns as FormDialog:
- Uses Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription, SheetFooter
- Handles loading states by disabling buttons and showing spinner
- Prevents closing when `isLoading` is true
- Supports custom button labels via props

## Props

- `open`, `onOpenChange` - Dialog visibility control
- `title` - Dialog title (e.g., "Delete Site")
- `description` - Confirmation message with optional `{name}` placeholder
- `itemName` - Optional item name for display (replaces `{name}` in description)
- `onConfirm`, `onCancel` - Action handlers
- `isLoading` - Loading state
- `confirmLabel`, `cancelLabel` - Custom button labels (defaults: "Delete", "Cancel")

## Testing

- [x] Component renders correctly
- [x] Loading state displays spinner and disables buttons
- [x] Item name replacement works in description
- [x] Dialog prevents closing during loading
- [x] No linting errors

## Related

Closes #84

Part of CRITICAL PRIORITY tasks - required for Sites and Partners CRUD pages.