### PR TITLE
feat: Implement Profile and Settings Pages

### DIFF
--- a/frontend/app/profile/page.tsx
+++ b/frontend/app/profile/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from 'next/navigation';
+import { getServerUser } from '@/lib/auth-server';
+import { ProfileContent } from './profile-content';
+
+export default async function ProfilePage() {
+  // Get user from server-side cookie
+  const user = await getServerUser();
+  
+  // Redirect to login if not authenticated
+  if (!user) {
+    redirect('/login?invalid_token=true');
+  }
+
+  // Pass user to client component
+  return <ProfileContent initialUser={user} />;
+}

--- a/frontend/app/profile/profile-content.tsx
+++ b/frontend/app/profile/profile-content.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import * as React from 'react';
+import { useAuth } from '@/contexts/auth-context';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { pageStyles } from '@/styles';
+import type { User } from '@/lib/api/auth';
+import { Loader2 } from 'lucide-react';
+
+interface ProfileContentProps {
+  initialUser: User;
+}
+
+export function ProfileContent({ initialUser }: ProfileContentProps) {
+  const { user, isLoading } = useAuth();
+  // Use user from context if available, otherwise use initialUser from server
+  const currentUser = user || initialUser;
+
+  // Check if user update endpoint exists by attempting to fetch it
+  // Since we know from the backend code that there's no update endpoint,
+  // we'll display read-only information with a note
+  const hasUpdateEndpoint = false; // Backend doesn't have user update endpoint
+
+  if (isLoading && !currentUser) {
+    return (
+      <div className={pageStyles.loadingContainer()}>
+        <div className="flex items-center gap-2">
+          <Loader2 className="h-6 w-6 animate-spin" />
+          <span className="text-sm text-muted-foreground">Loading profile...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (!currentUser) {
+    return (
+      <div>
+        <div className={pageStyles.dashboardHeader()}>
+          <div>
+            <h1 className={pageStyles.dashboardTitle()}>Profile</h1>
+            <p className={pageStyles.dashboardSubtitle()}>
+              Your account information
+            </p>
+          </div>
+        </div>
+
+        <Card className="mt-6 border-destructive">
+          <CardContent className="pt-6">
+            <p className="text-sm text-destructive">
+              Error loading profile. Please try again later.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className={pageStyles.dashboardHeader()}>
+        <div>
+          <h1 className={pageStyles.dashboardTitle()}>Profile</h1>
+          <p className={pageStyles.dashboardSubtitle()}>
+            Your account information
+          </p>
+        </div>
+      </div>
+
+      <div className="w-full max-w-2xl mx-auto mt-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>User Information</CardTitle>
+            <CardDescription>Your account details</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Email</label>
+                <p className="text-base mt-1">{currentUser.email}</p>
+                <p className="text-xs text-muted-foreground mt-1">Email cannot be changed</p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">First Name</label>
+                <p className="text-base mt-1">{currentUser.firstName || 'Not set'}</p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Last Name</label>
+                <p className="text-base mt-1">{currentUser.lastName || 'Not set'}</p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Role</label>
+                <div className="mt-1">
+                  <span className="inline-flex items-center rounded-full bg-primary/10 px-3 py-1 text-sm font-medium text-primary capitalize">
+                    {currentUser.role}
+                  </span>
+                </div>
+                <p className="text-xs text-muted-foreground mt-1">Role cannot be changed</p>
+              </div>
+
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">Account Status</label>
+                <div className="mt-1">
+                  <span
+                    className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium ${
+                      currentUser.isActive
+                        ? 'bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200'
+                        : 'bg-gray-100 text-gray-800 dark:bg-gray-900 dark:text-gray-200'
+                    }`}
+                  >
+                    {currentUser.isActive ? 'Active' : 'Inactive'}
+                  </span>
+                </div>
+              </div>
+
+              {currentUser.lastLoginAt && (
+                <div>
+                  <label className="text-sm font-medium text-muted-foreground">Last Login</label>
+                  <p className="text-base mt-1">
+                    {new Date(currentUser.lastLoginAt).toLocaleString()}
+                  </p>
+                </div>
+              )}
+
+              <div className="pt-4 border-t">
+                {!hasUpdateEndpoint && (
+                  <div className="rounded-md bg-muted p-4">
+                    <p className="text-sm text-muted-foreground">
+                      Profile editing is currently not available. This feature will be available soon.
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,0 +1,16 @@
+import { redirect } from 'next/navigation';
+import { getServerUser } from '@/lib/auth-server';
+import { SettingsContent } from './settings-content';
+
+export default async function SettingsPage() {
+  // Get user from server-side cookie
+  const user = await getServerUser();
+  
+  // Redirect to login if not authenticated
+  if (!user) {
+    redirect('/login?invalid_token=true');
+  }
+
+  // Pass user to client component
+  return <SettingsContent />;
+}

--- a/frontend/app/settings/settings-content.tsx
+++ b/frontend/app/settings/settings-content.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import * as React from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { pageStyles } from '@/styles';
+
+export function SettingsContent() {
+  return (
+    <div>
+      <div className={pageStyles.dashboardHeader()}>
+        <div>
+          <h1 className={pageStyles.dashboardTitle()}>Settings</h1>
+          <p className={pageStyles.dashboardSubtitle()}>
+            Manage your account settings and preferences
+          </p>
+        </div>
+      </div>
+
+      <div className="w-full max-w-4xl mx-auto mt-6 space-y-6">
+        {/* Account Settings Section */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Account Settings</CardTitle>
+            <CardDescription>
+              Manage your account information and security settings
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Account settings will be available here. This section will include options for
+              updating your profile, changing your password, and managing account security.
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Preferences Section */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Preferences</CardTitle>
+            <CardDescription>
+              Customize your application preferences and display settings
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Preference settings will be available here. This section will include options for
+              theme selection, language preferences, and other customization options.
+            </p>
+          </CardContent>
+        </Card>
+
+        {/* Notifications Section */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Notifications</CardTitle>
+            <CardDescription>
+              Configure how and when you receive notifications
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Notification settings will be available here. This section will include options for
+              email notifications, in-app notifications, and notification preferences.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

This PR implements the Profile and Settings pages as specified in the development plan (todos: profile-page, settings-page).

Closes #94

## Profile Page

- **Location**: `frontend/app/profile/page.tsx` and `frontend/app/profile/profile-content.tsx`
- **Features**:
  - Server component wrapper with authentication check
  - Client component for displaying user information
  - Displays user information:
    - Email (read-only)
    - First Name
    - Last Name
    - Role (displayed as badge)
    - Account Status (Active/Inactive badge)
    - Last Login timestamp (if available)
  - Read-only display with note about profile editing coming soon (backend doesn't have update endpoint yet)
  - Loading states with spinner
  - Error handling with user-friendly messages
  - Follows same patterns as dashboard page

## Settings Page

- **Location**: `frontend/app/settings/page.tsx` and `frontend/app/settings/settings-content.tsx`
- **Features**:
  - Server component wrapper with authentication check
  - Basic skeleton structure with placeholder sections:
    - Account Settings section
    - Preferences section
    - Notifications section
  - Uses Card components for layout
  - Matches existing page layout patterns
  - Ready for future implementation

## Technical Details

- Both pages use server-side authentication checks via `getServerUser()`
- Client components use React hooks and context for user data
- Follows existing code patterns from dashboard page
- Uses existing UI components (Card, pageStyles)
- Proper TypeScript types throughout
- No linting errors

## Testing

- [x] Pages load correctly when authenticated
- [x] Redirects to login when not authenticated
- [x] Loading states display correctly
- [x] Error states handle gracefully
- [x] User information displays correctly
- [x] Layout matches other pages

## Related

- Part of development plan todos: profile-page, settings-page
- Addresses missing pages referenced in sidebar navigation