### PR TITLE
fix: Boolean query parameters causing 400 Bad Request errors

### DIFF
--- a/backend/src/partners/dto/search-partners-query.dto.ts
+++ b/backend/src/partners/dto/search-partners-query.dto.ts
@@ -1,9 +1,15 @@
 import { IsOptional, IsBoolean, IsEnum } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 import { PartnerType } from './create-partner.dto';
 
 export class SearchPartnersQueryDto {
   @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
   @IsBoolean()
   @ApiProperty({
     description: 'Filter partners by active status',

--- a/backend/src/sites/dto/search-sites-query.dto.ts
+++ b/backend/src/sites/dto/search-sites-query.dto.ts
@@ -1,8 +1,14 @@
 import { IsOptional, IsBoolean, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
+import { Transform } from 'class-transformer';
 
 export class SearchSitesQueryDto {
   @IsOptional()
+  @Transform(({ value }) => {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+    return value;
+  })
   @IsBoolean()
   @ApiProperty({
     description: 'Filter sites by active status',


### PR DESCRIPTION
## Problem

When filtering Sites and Partners by `active` status using query parameters like `?active=true`, the backend returns 400 Bad Request errors.

## Root Cause

HTTP query parameters are always sent as strings, but the backend DTOs use `@IsBoolean()` validation which expects actual boolean values. When axios sends `{ active: true }`, it becomes `?active=true` (a string), which fails validation.

## Solution

Add `@Transform()` decorators to the `active` field in both:
- `SearchSitesQueryDto`
- `SearchPartnersQueryDto`

The transform converts string `'true'`/`'false'` to actual boolean values before validation.

## Files Modified

- `backend/src/sites/dto/search-sites-query.dto.ts`
- `backend/src/partners/dto/search-partners-query.dto.ts`

## Testing

- [x] Query with `?active=true` should work
- [x] Query with `?active=false` should work
- [x] Query without `active` parameter should still work
- [x] No linting errors