### PR TITLE
Phase 1: Curriculum taxonomy – DB migrations and TypeORM entities

### DIFF
--- a/backend/src/database/entities/curriculum-cluster.entity.ts
+++ b/backend/src/database/entities/curriculum-cluster.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from 'typeorm';
+import { CurriculumDomain } from './curriculum-domain.entity';
+import { CurriculumSkill } from './curriculum-skill.entity';
+
+@Entity('curriculum_clusters')
+export class CurriculumCluster {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'domain_id', type: 'uuid' })
+  domainId: string;
+
+  @ManyToOne(() => CurriculumDomain, (domain) => domain.clusters, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'domain_id' })
+  domain: CurriculumDomain;
+
+  @Column({ length: 20 })
+  code: string;
+
+  @Column({ length: 255 })
+  label: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @OneToMany(() => CurriculumSkill, (skill) => skill.cluster)
+  skills: CurriculumSkill[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/entities/curriculum-domain.entity.ts
+++ b/backend/src/database/entities/curriculum-domain.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from 'typeorm';
+import { CurriculumGrade } from './curriculum-grade.entity';
+import { CurriculumCluster } from './curriculum-cluster.entity';
+
+@Entity('curriculum_domains')
+export class CurriculumDomain {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'grade_id', type: 'uuid' })
+  gradeId: string;
+
+  @ManyToOne(() => CurriculumGrade, (grade) => grade.domains, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'grade_id' })
+  grade: CurriculumGrade;
+
+  @Column({ length: 20 })
+  code: string;
+
+  @Column({ length: 255 })
+  label: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @OneToMany(() => CurriculumCluster, (cluster) => cluster.domain)
+  clusters: CurriculumCluster[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/entities/curriculum-grade.entity.ts
+++ b/backend/src/database/entities/curriculum-grade.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+} from 'typeorm';
+import { Service } from './service.entity';
+import { CurriculumDomain } from './curriculum-domain.entity';
+
+@Entity('curriculum_grades')
+export class CurriculumGrade {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'service_id', type: 'uuid' })
+  serviceId: string;
+
+  @ManyToOne(() => Service, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'service_id' })
+  service: Service;
+
+  @Column({ length: 20 })
+  code: string;
+
+  @Column({ length: 100 })
+  label: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @OneToMany(() => CurriculumDomain, (domain) => domain.grade)
+  domains: CurriculumDomain[];
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/entities/curriculum-skill.entity.ts
+++ b/backend/src/database/entities/curriculum-skill.entity.ts
@@ -1,0 +1,38 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  ManyToOne,
+  JoinColumn,
+} from 'typeorm';
+import { CurriculumCluster } from './curriculum-cluster.entity';
+
+@Entity('curriculum_skills')
+export class CurriculumSkill {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ name: 'cluster_id', type: 'uuid' })
+  clusterId: string;
+
+  @ManyToOne(() => CurriculumCluster, (cluster) => cluster.skills, { onDelete: 'RESTRICT' })
+  @JoinColumn({ name: 'cluster_id' })
+  cluster: CurriculumCluster;
+
+  @Column({ length: 20 })
+  code: string;
+
+  @Column({ length: 500 })
+  label: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt: Date;
+
+  @UpdateDateColumn({ name: 'updated_at' })
+  updatedAt: Date;
+}

--- a/backend/src/database/entities/index.ts
+++ b/backend/src/database/entities/index.ts
@@ -21,4 +21,8 @@ export { ActionItem } from './action-item.entity';
 export { Recommendation } from './recommendation.entity';
 export { AuditLog } from './audit-log.entity';
 export { Notification } from './notification.entity';
+export { CurriculumGrade } from './curriculum-grade.entity';
+export { CurriculumDomain } from './curriculum-domain.entity';
+export { CurriculumCluster } from './curriculum-cluster.entity';
+export { CurriculumSkill } from './curriculum-skill.entity';
 

--- a/database/migrations/025_create_curriculum_grades_table.sql
+++ b/database/migrations/025_create_curriculum_grades_table.sql
@@ -1,0 +1,21 @@
+-- Migration: 025_create_curriculum_grades_table.sql
+-- Description: Create curriculum_grades table (grade level per subject, e.g. K, 1, 2, ... 8, HS)
+
+CREATE TABLE curriculum_grades (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    service_id UUID NOT NULL REFERENCES services(id) ON DELETE RESTRICT,
+    code VARCHAR(20) NOT NULL,
+    label VARCHAR(100) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(service_id, code)
+);
+
+-- Indexes
+CREATE INDEX idx_curriculum_grades_service_id ON curriculum_grades(service_id);
+CREATE INDEX idx_curriculum_grades_code ON curriculum_grades(code);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER update_curriculum_grades_updated_at BEFORE UPDATE ON curriculum_grades
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/database/migrations/026_create_curriculum_domains_table.sql
+++ b/database/migrations/026_create_curriculum_domains_table.sql
@@ -1,0 +1,21 @@
+-- Migration: 026_create_curriculum_domains_table.sql
+-- Description: Create curriculum_domains table (domain per grade, e.g. OA, NBT)
+
+CREATE TABLE curriculum_domains (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    grade_id UUID NOT NULL REFERENCES curriculum_grades(id) ON DELETE RESTRICT,
+    code VARCHAR(20) NOT NULL,
+    label VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(grade_id, code)
+);
+
+-- Indexes
+CREATE INDEX idx_curriculum_domains_grade_id ON curriculum_domains(grade_id);
+CREATE INDEX idx_curriculum_domains_code ON curriculum_domains(code);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER update_curriculum_domains_updated_at BEFORE UPDATE ON curriculum_domains
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/database/migrations/027_create_curriculum_clusters_table.sql
+++ b/database/migrations/027_create_curriculum_clusters_table.sql
@@ -1,0 +1,21 @@
+-- Migration: 027_create_curriculum_clusters_table.sql
+-- Description: Create curriculum_clusters table (cluster per domain, e.g. A, B)
+
+CREATE TABLE curriculum_clusters (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    domain_id UUID NOT NULL REFERENCES curriculum_domains(id) ON DELETE RESTRICT,
+    code VARCHAR(20) NOT NULL,
+    label VARCHAR(255) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(domain_id, code)
+);
+
+-- Indexes
+CREATE INDEX idx_curriculum_clusters_domain_id ON curriculum_clusters(domain_id);
+CREATE INDEX idx_curriculum_clusters_code ON curriculum_clusters(code);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER update_curriculum_clusters_updated_at BEFORE UPDATE ON curriculum_clusters
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/database/migrations/028_create_curriculum_skills_table.sql
+++ b/database/migrations/028_create_curriculum_skills_table.sql
@@ -1,0 +1,21 @@
+-- Migration: 028_create_curriculum_skills_table.sql
+-- Description: Create curriculum_skills table (skill per cluster; full code = grade.domain.cluster.skill e.g. 1.OA.A.1)
+
+CREATE TABLE curriculum_skills (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    cluster_id UUID NOT NULL REFERENCES curriculum_clusters(id) ON DELETE RESTRICT,
+    code VARCHAR(20) NOT NULL,
+    label VARCHAR(500) NOT NULL,
+    description TEXT,
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(cluster_id, code)
+);
+
+-- Indexes
+CREATE INDEX idx_curriculum_skills_cluster_id ON curriculum_skills(cluster_id);
+CREATE INDEX idx_curriculum_skills_code ON curriculum_skills(code);
+
+-- Trigger to auto-update updated_at
+CREATE TRIGGER update_curriculum_skills_updated_at BEFORE UPDATE ON curriculum_skills
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
Implements **Phase 1** of the Coherence Map Curriculum Integration (Option A: four-table hierarchy).

## Changes
- **Migrations:** `curriculum_grades`, `curriculum_domains`, `curriculum_clusters`, `curriculum_skills` with code, label, description, parent FKs, and `service_id` on grades.
- **Entities:** TypeORM entities with relations (Grade → Service; Domain → Grade; Cluster → Domain; Skill → Cluster).
- **Exports:** New entities exported from `backend/src/database/entities/index.ts`.

Full taxonomy code convention: `grade.domain.cluster.skill` (e.g. `1.OA.A.1`).

Closes #100