### PR TITLE
Phase 2: Session-taxonomy link (skill_id/cluster_id on sessions)

### DIFF
--- a/backend/src/database/entities/session.entity.ts
+++ b/backend/src/database/entities/session.entity.ts
@@ -6,9 +6,12 @@ import {
   UpdateDateColumn,
   ManyToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { Tutor } from './tutor.entity';
 import { Site } from './site.entity';
+import { CurriculumCluster } from './curriculum-cluster.entity';
+import { CurriculumSkill } from './curriculum-skill.entity';
 
 @Entity('sessions')
 export class Session {
@@ -28,6 +31,22 @@ export class Session {
   @ManyToOne(() => Site, { onDelete: 'RESTRICT' })
   @JoinColumn({ name: 'site_id' })
   site: Site;
+
+  @Index('idx_sessions_cluster_id')
+  @Column({ name: 'cluster_id', type: 'uuid', nullable: true })
+  clusterId: string | null;
+
+  @ManyToOne(() => CurriculumCluster, { onDelete: 'RESTRICT', nullable: true })
+  @JoinColumn({ name: 'cluster_id' })
+  cluster: CurriculumCluster | null;
+
+  @Index('idx_sessions_skill_id')
+  @Column({ name: 'skill_id', type: 'uuid', nullable: true })
+  skillId: string | null;
+
+  @ManyToOne(() => CurriculumSkill, { onDelete: 'RESTRICT', nullable: true })
+  @JoinColumn({ name: 'skill_id' })
+  skill: CurriculumSkill | null;
 
   @Column({ name: 'session_date', type: 'date' })
   sessionDate: Date;
@@ -60,4 +79,3 @@ export class Session {
   @UpdateDateColumn({ name: 'updated_at' })
   updatedAt: Date;
 }
-

--- a/database/README.md
+++ b/database/README.md
@@ -85,7 +85,14 @@ Migration `029_seed_math_ela_sel_curriculum.sql` seeds:
 
 Run this migration after the curriculum table migrations (025–028).
 
+## Session taxonomy link
+
+Migration `030_add_taxonomy_links_to_sessions.sql` adds optional `cluster_id` and `skill_id`
+references on `sessions` to support curriculum-aligned session reporting.
+
+- `session_topics` remains available for free-form tags.
+- `cluster_id` / `skill_id` is the primary curriculum taxonomy association for a session.
+
 ## Next Steps
 
 Database migrations will be added systematically through GitHub issues and PRs, starting with the "Database Setup" feature.
-

--- a/database/migrations/030_add_taxonomy_links_to_sessions.sql
+++ b/database/migrations/030_add_taxonomy_links_to_sessions.sql
@@ -1,0 +1,16 @@
+-- Migration: 030_add_taxonomy_links_to_sessions.sql
+-- Description: Add taxonomy references to sessions for curriculum-aligned reporting/filtering
+
+ALTER TABLE sessions
+ADD COLUMN cluster_id UUID REFERENCES curriculum_clusters(id) ON DELETE RESTRICT,
+ADD COLUMN skill_id UUID REFERENCES curriculum_skills(id) ON DELETE RESTRICT;
+
+-- Indexes for report and filter queries
+CREATE INDEX idx_sessions_cluster_id ON sessions(cluster_id);
+CREATE INDEX idx_sessions_skill_id ON sessions(skill_id);
+CREATE INDEX idx_sessions_session_date_cluster_id ON sessions(session_date, cluster_id);
+CREATE INDEX idx_sessions_session_date_skill_id ON sessions(session_date, skill_id);
+
+-- Notes:
+-- 1) session_topics remains available for free-form tags.
+-- 2) curriculum cluster/skill is the canonical taxonomy link for curriculum-driven reporting.

--- a/database/setup.sql
+++ b/database/setup.sql
@@ -36,10 +36,16 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 \i migrations/021_create_recommendations_table.sql
 \i migrations/022_create_audit_logs_table.sql
 \i migrations/023_create_notifications_table.sql
+\i migrations/024_add_oauth_support.sql
+\i migrations/025_create_curriculum_grades_table.sql
+\i migrations/026_create_curriculum_domains_table.sql
+\i migrations/027_create_curriculum_clusters_table.sql
+\i migrations/028_create_curriculum_skills_table.sql
+\i migrations/029_seed_math_ela_sel_curriculum.sql
+\i migrations/030_add_taxonomy_links_to_sessions.sql
 
 -- Verify tables were created
 SELECT table_name 
 FROM information_schema.tables 
 WHERE table_schema = 'public' 
 ORDER BY table_name;
-


### PR DESCRIPTION
## Summary
- Add migration to link sessions to curriculum cluster/skill
- Add session entity relations and reporting indexes
- Update database setup/docs for new migration

Closes #103