### PR TITLE
feat(availability): implement full availability module

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -12,6 +12,7 @@ import { SessionsModule } from './sessions/sessions.module';
 import { CurriculumModule } from './curriculum/curriculum.module';
 import { ActionItemsModule } from './action-items/action-items.module';
 import { ReportsModule } from './reports/reports.module';
+import { AvailabilityModule } from './availability/availability.module';
 
 @Module({
   imports: [
@@ -28,6 +29,7 @@ import { ReportsModule } from './reports/reports.module';
       CurriculumModule,
       ActionItemsModule,
       ReportsModule,
+      AvailabilityModule,
     ],
   controllers: [AppController],
   providers: [AppService],

--- a/backend/src/availability/availability.controller.ts
+++ b/backend/src/availability/availability.controller.ts
@@ -1,0 +1,110 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Query,
+  UseGuards,
+} from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiBody,
+  ApiForbiddenResponse,
+  ApiOperation,
+  ApiParam,
+  ApiQuery,
+  ApiResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { AvailabilityService } from './availability.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { RolesGuard } from '../auth/guards/roles.guard';
+import { Roles } from '../auth/decorators/roles.decorator';
+import { CurrentUser } from '../auth/decorators/current-user.decorator';
+import { Role } from '../common/roles/roles.enum';
+import { User } from '../database/entities/user.entity';
+import { CreateAvailabilityDto } from './dto/create-availability.dto';
+import { UpdateAvailabilityDto } from './dto/update-availability.dto';
+import { SearchAvailabilityQueryDto } from './dto/search-availability-query.dto';
+import { AvailabilityResponseDto } from './dto/availability-response.dto';
+import { MessageCode, Messages } from '../common/messages';
+
+@Controller('availability')
+@UseGuards(JwtAuthGuard)
+@ApiTags('Availability')
+@ApiBearerAuth()
+export class AvailabilityController {
+  constructor(private readonly availabilityService: AvailabilityService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.TUTOR, Role.ADMIN, Role.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Create an availability slot' })
+  @ApiBody({ type: CreateAvailabilityDto })
+  @ApiResponse({ status: 201, description: 'Availability slot created', type: AvailabilityResponseDto })
+  @ApiForbiddenResponse({ description: Messages[MessageCode.INSUFFICIENT_PERMISSIONS] })
+  async create(
+    @Body() dto: CreateAvailabilityDto,
+    @CurrentUser() user: User,
+  ): Promise<AvailabilityResponseDto> {
+    return this.availabilityService.create(dto, user);
+  }
+
+  @Get()
+  @ApiOperation({ summary: 'List availability slots with optional filters' })
+  @ApiQuery({ name: 'tutorId', required: false })
+  @ApiQuery({ name: 'dayOfWeek', required: false, description: '0=Sunday, 6=Saturday' })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  @ApiResponse({ status: 200, description: 'Availability slots fetched', type: [AvailabilityResponseDto] })
+  async getAll(
+    @Query() query: SearchAvailabilityQueryDto,
+    @CurrentUser() user: User,
+  ): Promise<AvailabilityResponseDto[]> {
+    return this.availabilityService.getAll(query, user);
+  }
+
+  @Get(':id')
+  @ApiOperation({ summary: 'Get an availability slot by ID' })
+  @ApiParam({ name: 'id', description: 'Availability ID' })
+  @ApiResponse({ status: 200, description: 'Availability slot fetched', type: AvailabilityResponseDto })
+  async getById(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ): Promise<AvailabilityResponseDto> {
+    return this.availabilityService.getById(id, user);
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.TUTOR, Role.ADMIN, Role.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Update an availability slot by ID' })
+  @ApiParam({ name: 'id', description: 'Availability ID' })
+  @ApiBody({ type: UpdateAvailabilityDto })
+  @ApiResponse({ status: 200, description: 'Availability slot updated', type: AvailabilityResponseDto })
+  @ApiForbiddenResponse({ description: Messages[MessageCode.INSUFFICIENT_PERMISSIONS] })
+  async update(
+    @Param('id') id: string,
+    @Body() dto: UpdateAvailabilityDto,
+    @CurrentUser() user: User,
+  ): Promise<AvailabilityResponseDto> {
+    return this.availabilityService.update(id, dto, user);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard, RolesGuard)
+  @Roles(Role.TUTOR, Role.ADMIN, Role.SUPER_ADMIN)
+  @ApiOperation({ summary: 'Delete an availability slot by ID' })
+  @ApiParam({ name: 'id', description: 'Availability ID' })
+  @ApiResponse({ status: 200, description: 'Availability slot deleted' })
+  @ApiForbiddenResponse({ description: Messages[MessageCode.INSUFFICIENT_PERMISSIONS] })
+  async delete(
+    @Param('id') id: string,
+    @CurrentUser() user: User,
+  ): Promise<void> {
+    return this.availabilityService.delete(id, user);
+  }
+}

--- a/backend/src/availability/availability.module.ts
+++ b/backend/src/availability/availability.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AvailabilityController } from './availability.controller';
+import { AvailabilityService } from './availability.service';
+import { Availability } from '../database/entities/availability.entity';
+import { Tutor } from '../database/entities/tutor.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Availability, Tutor])],
+  controllers: [AvailabilityController],
+  providers: [AvailabilityService],
+  exports: [AvailabilityService],
+})
+export class AvailabilityModule {}

--- a/backend/src/availability/availability.service.ts
+++ b/backend/src/availability/availability.service.ts
@@ -1,0 +1,215 @@
+import {
+  BadRequestException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Availability } from '../database/entities/availability.entity';
+import { Tutor } from '../database/entities/tutor.entity';
+import { User } from '../database/entities/user.entity';
+import { Role } from '../common/roles/roles.enum';
+import { CreateAvailabilityDto } from './dto/create-availability.dto';
+import { UpdateAvailabilityDto } from './dto/update-availability.dto';
+import { SearchAvailabilityQueryDto } from './dto/search-availability-query.dto';
+import { AvailabilityResponseDto } from './dto/availability-response.dto';
+
+@Injectable()
+export class AvailabilityService {
+  constructor(
+    @InjectRepository(Availability)
+    private readonly availabilityRepository: Repository<Availability>,
+    @InjectRepository(Tutor)
+    private readonly tutorRepository: Repository<Tutor>,
+  ) {}
+
+  async create(dto: CreateAvailabilityDto, currentUser: User): Promise<AvailabilityResponseDto> {
+    const tutorId = await this.resolveCreateTutorId(dto.tutorId, currentUser);
+    const isRecurring = dto.isRecurring ?? true;
+
+    this.validateRecurringConstraints(isRecurring, dto.dayOfWeek, dto.specificDate);
+
+    const availability = this.availabilityRepository.create({
+      tutorId,
+      dayOfWeek: isRecurring ? dto.dayOfWeek : null,
+      startTime: dto.startTime,
+      endTime: dto.endTime,
+      isRecurring,
+      specificDate: !isRecurring && dto.specificDate ? new Date(dto.specificDate) : null,
+      effectiveFrom: dto.effectiveFrom ? new Date(dto.effectiveFrom) : null,
+      effectiveUntil: dto.effectiveUntil ? new Date(dto.effectiveUntil) : null,
+    });
+
+    const saved = await this.availabilityRepository.save(availability);
+    return this.mapToResponse(saved);
+  }
+
+  async getAll(query: SearchAvailabilityQueryDto, currentUser: User): Promise<AvailabilityResponseDto[]> {
+    const qb = this.availabilityRepository.createQueryBuilder('availability');
+
+    if (currentUser.role === Role.TUTOR) {
+      qb.andWhere('availability.tutorId = :tutorId', { tutorId: currentUser.id });
+    } else if (query?.tutorId) {
+      qb.andWhere('availability.tutorId = :tutorId', { tutorId: query.tutorId });
+    }
+
+    if (query?.dayOfWeek !== undefined) {
+      qb.andWhere('availability.dayOfWeek = :dayOfWeek', { dayOfWeek: query.dayOfWeek });
+    }
+
+    if (query?.startDate) {
+      qb.andWhere('availability.specificDate >= :startDate', { startDate: query.startDate });
+    }
+
+    if (query?.endDate) {
+      qb.andWhere('availability.specificDate <= :endDate', { endDate: query.endDate });
+    }
+
+    qb.orderBy('availability.createdAt', 'DESC');
+
+    const records = await qb.getMany();
+    return records.map((a) => this.mapToResponse(a));
+  }
+
+  async getById(id: string, currentUser: User): Promise<AvailabilityResponseDto> {
+    const availability = await this.findForAccess(id, currentUser);
+    return this.mapToResponse(availability);
+  }
+
+  async update(id: string, dto: UpdateAvailabilityDto, currentUser: User): Promise<AvailabilityResponseDto> {
+    const availability = await this.findForAccess(id, currentUser);
+
+    if (dto.tutorId !== undefined && currentUser.role !== Role.TUTOR) {
+      await this.ensureTutorExists(dto.tutorId);
+      availability.tutorId = dto.tutorId;
+    }
+
+    const isRecurring = dto.isRecurring !== undefined ? dto.isRecurring : availability.isRecurring;
+
+    // Determine the effective dayOfWeek and specificDate after update
+    const newDayOfWeek = dto.dayOfWeek !== undefined ? dto.dayOfWeek : availability.dayOfWeek;
+    const newSpecificDate =
+      dto.specificDate !== undefined
+        ? dto.specificDate
+        : availability.specificDate
+          ? availability.specificDate.toISOString().split('T')[0]
+          : undefined;
+
+    this.validateRecurringConstraints(isRecurring, newDayOfWeek, newSpecificDate);
+
+    if (dto.startTime !== undefined) availability.startTime = dto.startTime;
+    if (dto.endTime !== undefined) availability.endTime = dto.endTime;
+    availability.isRecurring = isRecurring;
+
+    if (isRecurring) {
+      availability.dayOfWeek = newDayOfWeek ?? null;
+      availability.specificDate = null;
+    } else {
+      availability.dayOfWeek = null;
+      availability.specificDate = newSpecificDate ? new Date(newSpecificDate) : null;
+    }
+
+    if (dto.effectiveFrom !== undefined) {
+      availability.effectiveFrom = dto.effectiveFrom ? new Date(dto.effectiveFrom) : null;
+    }
+    if (dto.effectiveUntil !== undefined) {
+      availability.effectiveUntil = dto.effectiveUntil ? new Date(dto.effectiveUntil) : null;
+    }
+
+    const saved = await this.availabilityRepository.save(availability);
+    return this.mapToResponse(saved);
+  }
+
+  async delete(id: string, currentUser: User): Promise<void> {
+    await this.findForAccess(id, currentUser);
+    await this.availabilityRepository.delete(id);
+  }
+
+  private async findForAccess(id: string, currentUser: User): Promise<Availability> {
+    const availability = await this.availabilityRepository.findOne({ where: { id } });
+
+    if (!availability) {
+      throw new NotFoundException('Availability slot not found');
+    }
+
+    if (currentUser.role === Role.TUTOR && availability.tutorId !== currentUser.id) {
+      throw new NotFoundException('Availability slot not found');
+    }
+
+    return availability;
+  }
+
+  private async resolveCreateTutorId(tutorId: string | undefined, currentUser: User): Promise<string> {
+    if (currentUser.role === Role.TUTOR) {
+      if (tutorId && tutorId !== currentUser.id) {
+        throw new BadRequestException('Tutors can only create availability for themselves');
+      }
+      await this.ensureTutorExists(currentUser.id);
+      return currentUser.id;
+    }
+
+    if (!tutorId) {
+      throw new BadRequestException('tutorId is required for admin and super_admin users');
+    }
+
+    await this.ensureTutorExists(tutorId);
+    return tutorId;
+  }
+
+  private async ensureTutorExists(tutorId: string): Promise<void> {
+    const tutor = await this.tutorRepository.findOne({ where: { userId: tutorId } });
+    if (!tutor) {
+      throw new NotFoundException('Tutor not found');
+    }
+  }
+
+  private validateRecurringConstraints(
+    isRecurring: boolean,
+    dayOfWeek: number | null | undefined,
+    specificDate: string | null | undefined,
+  ): void {
+    if (isRecurring) {
+      if (dayOfWeek === null || dayOfWeek === undefined) {
+        throw new BadRequestException('dayOfWeek is required for recurring availability slots');
+      }
+      if (specificDate) {
+        throw new BadRequestException('specificDate must not be set for recurring availability slots');
+      }
+    } else {
+      if (!specificDate) {
+        throw new BadRequestException('specificDate is required for non-recurring availability slots');
+      }
+      if (dayOfWeek !== null && dayOfWeek !== undefined) {
+        throw new BadRequestException('dayOfWeek must not be set for non-recurring availability slots');
+      }
+    }
+  }
+
+  private mapToResponse(availability: Availability): AvailabilityResponseDto {
+    return {
+      id: availability.id,
+      tutorId: availability.tutorId,
+      dayOfWeek: availability.dayOfWeek ?? null,
+      startTime: availability.startTime,
+      endTime: availability.endTime,
+      isRecurring: availability.isRecurring,
+      specificDate: availability.specificDate
+        ? availability.specificDate instanceof Date
+          ? availability.specificDate.toISOString().split('T')[0]
+          : String(availability.specificDate)
+        : null,
+      effectiveFrom: availability.effectiveFrom
+        ? availability.effectiveFrom instanceof Date
+          ? availability.effectiveFrom.toISOString().split('T')[0]
+          : String(availability.effectiveFrom)
+        : null,
+      effectiveUntil: availability.effectiveUntil
+        ? availability.effectiveUntil instanceof Date
+          ? availability.effectiveUntil.toISOString().split('T')[0]
+          : String(availability.effectiveUntil)
+        : null,
+      createdAt: availability.createdAt,
+      updatedAt: availability.updatedAt,
+    };
+  }
+}

--- a/backend/src/availability/dto/availability-response.dto.ts
+++ b/backend/src/availability/dto/availability-response.dto.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AvailabilityResponseDto {
+  @ApiProperty({ description: 'Availability ID' })
+  id: string;
+
+  @ApiProperty({ description: 'Tutor user ID' })
+  tutorId: string;
+
+  @ApiProperty({ description: 'Day of week (0=Sunday, 6=Saturday)', nullable: true })
+  dayOfWeek: number | null;
+
+  @ApiProperty({ description: 'Start time (HH:mm)' })
+  startTime: string;
+
+  @ApiProperty({ description: 'End time (HH:mm)' })
+  endTime: string;
+
+  @ApiProperty({ description: 'Whether this is a recurring weekly slot' })
+  isRecurring: boolean;
+
+  @ApiProperty({ description: 'Specific date for one-off slots', nullable: true })
+  specificDate: string | null;
+
+  @ApiProperty({ description: 'Effective from date for recurring slots', nullable: true })
+  effectiveFrom: string | null;
+
+  @ApiProperty({ description: 'Effective until date for recurring slots', nullable: true })
+  effectiveUntil: string | null;
+
+  @ApiProperty({ description: 'Creation timestamp' })
+  createdAt: Date;
+
+  @ApiProperty({ description: 'Update timestamp' })
+  updatedAt: Date;
+}

--- a/backend/src/availability/dto/create-availability.dto.ts
+++ b/backend/src/availability/dto/create-availability.dto.ts
@@ -1,0 +1,91 @@
+import {
+  IsBoolean,
+  IsDateString,
+  IsInt,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Matches,
+  Max,
+  Min,
+} from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class CreateAvailabilityDto {
+  @IsOptional()
+  @IsUUID()
+  @ApiProperty({
+    description: 'Tutor ID. Optional for tutors (auto-derived from authenticated user).',
+    required: false,
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  tutorId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(0)
+  @Max(6)
+  @ApiProperty({
+    description: 'Day of week (0=Sunday, 6=Saturday). Required when isRecurring=true.',
+    required: false,
+    minimum: 0,
+    maximum: 6,
+    example: 1,
+  })
+  dayOfWeek?: number;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/)
+  @ApiProperty({
+    description: 'Start time in HH:mm format.',
+    example: '09:00',
+  })
+  startTime: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Matches(/^([01]\d|2[0-3]):([0-5]\d)$/)
+  @ApiProperty({
+    description: 'End time in HH:mm format.',
+    example: '11:00',
+  })
+  endTime: string;
+
+  @IsOptional()
+  @IsBoolean()
+  @ApiProperty({
+    description: 'Whether this is a recurring weekly slot. Defaults to true.',
+    required: false,
+    default: true,
+  })
+  isRecurring?: boolean;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiProperty({
+    description: 'Specific date for non-recurring slots (YYYY-MM-DD). Required when isRecurring=false.',
+    required: false,
+    example: '2026-03-15',
+  })
+  specificDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiProperty({
+    description: 'Date from which recurring slot is effective (YYYY-MM-DD).',
+    required: false,
+    example: '2026-01-01',
+  })
+  effectiveFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiProperty({
+    description: 'Date until which recurring slot is effective (YYYY-MM-DD).',
+    required: false,
+    example: '2026-12-31',
+  })
+  effectiveUntil?: string;
+}

--- a/backend/src/availability/dto/search-availability-query.dto.ts
+++ b/backend/src/availability/dto/search-availability-query.dto.ts
@@ -1,0 +1,42 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsDateString, IsInt, IsOptional, IsUUID, Max, Min } from 'class-validator';
+import { Transform } from 'class-transformer';
+
+export class SearchAvailabilityQueryDto {
+  @IsOptional()
+  @IsUUID()
+  @ApiProperty({
+    description: 'Filter by tutor ID (admin/super_admin only).',
+    required: false,
+  })
+  tutorId?: string;
+
+  @IsOptional()
+  @Transform(({ value }) => (value !== undefined ? Number(value) : undefined))
+  @IsInt()
+  @Min(0)
+  @Max(6)
+  @ApiProperty({
+    description: 'Filter by day of week (0=Sunday, 6=Saturday).',
+    required: false,
+    minimum: 0,
+    maximum: 6,
+  })
+  dayOfWeek?: number;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiProperty({
+    description: 'Inclusive start date filter (YYYY-MM-DD).',
+    required: false,
+  })
+  startDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  @ApiProperty({
+    description: 'Inclusive end date filter (YYYY-MM-DD).',
+    required: false,
+  })
+  endDate?: string;
+}

--- a/backend/src/availability/dto/update-availability.dto.ts
+++ b/backend/src/availability/dto/update-availability.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/swagger';
+import { CreateAvailabilityDto } from './create-availability.dto';
+
+export class UpdateAvailabilityDto extends PartialType(CreateAvailabilityDto) {}

--- a/frontend/app/availability/availability-content.tsx
+++ b/frontend/app/availability/availability-content.tsx
@@ -1,0 +1,282 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { DataTable, type ColumnDef } from '@/components/ui/data-table';
+import { FormDialog } from '@/components/ui/form-dialog';
+import { DeleteDialog } from '@/components/ui/delete-dialog';
+import { useToast } from '@/hooks/use-toast';
+import {
+  availabilityApi,
+  type Availability,
+  type CreateAvailabilityDto,
+} from '@/lib/api/availability';
+import { getErrorMessage } from '@/lib/api-client';
+import { pageStyles } from '@/styles';
+import { AvailabilityForm, type AvailabilityFormRef } from './availability-form';
+
+const DAY_LABELS = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+
+export function AvailabilityContent() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // Dialog states
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = React.useState(false);
+  const [isEditDialogOpen, setIsEditDialogOpen] = React.useState(false);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = React.useState(false);
+  const [selected, setSelected] = React.useState<Availability | null>(null);
+
+  // Form refs
+  const createFormRef = React.useRef<AvailabilityFormRef>(null);
+  const editFormRef = React.useRef<AvailabilityFormRef>(null);
+
+  const {
+    data: slots = [],
+    isLoading,
+    error,
+  } = useQuery({
+    queryKey: ['availability'],
+    queryFn: () => availabilityApi.getAll(),
+  });
+
+  const createMutation = useMutation({
+    mutationFn: (data: CreateAvailabilityDto) => availabilityApi.create(data),
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Availability slot created' });
+      setIsCreateDialogOpen(false);
+      queryClient.invalidateQueries({ queryKey: ['availability'] });
+    },
+    onError: (error: unknown) => {
+      toast({ title: 'Error', description: getErrorMessage(error), variant: 'destructive' });
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: CreateAvailabilityDto }) =>
+      availabilityApi.update(id, data),
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Availability slot updated' });
+      setIsEditDialogOpen(false);
+      setSelected(null);
+      queryClient.invalidateQueries({ queryKey: ['availability'] });
+    },
+    onError: (error: unknown) => {
+      toast({ title: 'Error', description: getErrorMessage(error), variant: 'destructive' });
+    },
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => availabilityApi.delete(id),
+    onSuccess: () => {
+      toast({ title: 'Success', description: 'Availability slot deleted' });
+      setIsDeleteDialogOpen(false);
+      setSelected(null);
+      queryClient.invalidateQueries({ queryKey: ['availability'] });
+    },
+    onError: (error: unknown) => {
+      toast({ title: 'Error', description: getErrorMessage(error), variant: 'destructive' });
+    },
+  });
+
+  const handleCreate = () => {
+    setSelected(null);
+    setIsCreateDialogOpen(true);
+  };
+
+  const handleEdit = (slot: Availability) => {
+    setSelected(slot);
+    setIsEditDialogOpen(true);
+  };
+
+  const handleDelete = (slot: Availability) => {
+    setSelected(slot);
+    setIsDeleteDialogOpen(true);
+  };
+
+  const handleCreateSubmit = async (data: CreateAvailabilityDto) => {
+    await createMutation.mutateAsync(data);
+  };
+
+  const handleEditSubmit = async (data: CreateAvailabilityDto) => {
+    if (selected) {
+      await updateMutation.mutateAsync({ id: selected.id, data });
+    }
+  };
+
+  const handleDeleteConfirm = async () => {
+    if (selected) {
+      await deleteMutation.mutateAsync(selected.id);
+    }
+  };
+
+  const columns: ColumnDef<Availability>[] = [
+    {
+      id: 'type',
+      header: 'Type',
+      cell: (row) => (
+        <span
+          className={`inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium ${
+            row.isRecurring
+              ? 'bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200'
+              : 'bg-purple-100 text-purple-800 dark:bg-purple-900 dark:text-purple-200'
+          }`}
+        >
+          {row.isRecurring ? 'Recurring' : 'One-off'}
+        </span>
+      ),
+    },
+    {
+      id: 'schedule',
+      header: 'Schedule',
+      cell: (row) => {
+        if (row.isRecurring && row.dayOfWeek !== null && row.dayOfWeek !== undefined) {
+          return DAY_LABELS[row.dayOfWeek] ?? `Day ${row.dayOfWeek}`;
+        }
+        if (!row.isRecurring && row.specificDate) {
+          return new Date(row.specificDate + 'T00:00:00').toLocaleDateString('en-US', {
+            year: 'numeric',
+            month: 'short',
+            day: 'numeric',
+          });
+        }
+        return <span className="text-muted-foreground">—</span>;
+      },
+    },
+    {
+      id: 'time',
+      header: 'Time',
+      cell: (row) => `${row.startTime} – ${row.endTime}`,
+    },
+    {
+      id: 'effective',
+      header: 'Effective',
+      cell: (row) => {
+        if (!row.effectiveFrom && !row.effectiveUntil) {
+          return <span className="text-muted-foreground">Always</span>;
+        }
+        const from = row.effectiveFrom
+          ? new Date(row.effectiveFrom + 'T00:00:00').toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })
+          : '…';
+        const until = row.effectiveUntil
+          ? new Date(row.effectiveUntil + 'T00:00:00').toLocaleDateString('en-US', {
+              month: 'short',
+              day: 'numeric',
+              year: 'numeric',
+            })
+          : '…';
+        return `${from} – ${until}`;
+      },
+    },
+  ];
+
+  // Derive a display name for delete dialog
+  const getSlotLabel = (slot: Availability | null): string => {
+    if (!slot) return '';
+    if (slot.isRecurring && slot.dayOfWeek !== null && slot.dayOfWeek !== undefined) {
+      return `${DAY_LABELS[slot.dayOfWeek]} ${slot.startTime}–${slot.endTime}`;
+    }
+    if (slot.specificDate) {
+      return `${slot.specificDate} ${slot.startTime}–${slot.endTime}`;
+    }
+    return `${slot.startTime}–${slot.endTime}`;
+  };
+
+  return (
+    <div>
+      <div className={pageStyles.dashboardHeader()}>
+        <div>
+          <h1 className={pageStyles.dashboardTitle()}>Availability</h1>
+          <p className={pageStyles.dashboardSubtitle()}>Manage your tutoring availability slots</p>
+        </div>
+        <Button onClick={handleCreate}>
+          <Plus className="mr-2 h-4 w-4" />
+          Add Slot
+        </Button>
+      </div>
+
+      <div className="w-full max-w-5xl mx-auto mt-6">
+        {error && (
+          <div className="mb-4 p-4 bg-destructive/10 text-destructive rounded-md">
+            <p className="font-medium">Failed to load availability slots</p>
+            <p className="text-sm mt-1">{getErrorMessage(error)}</p>
+          </div>
+        )}
+
+        <DataTable
+          data={slots}
+          columns={columns}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          isLoading={isLoading}
+          emptyMessage="No availability slots found"
+        />
+      </div>
+
+      {/* Create Dialog */}
+      <FormDialog
+        open={isCreateDialogOpen}
+        onOpenChange={setIsCreateDialogOpen}
+        title="Add Availability Slot"
+        description="Define a new availability window for tutoring sessions"
+        onSubmit={async () => {
+          await createFormRef.current?.submit();
+        }}
+        onCancel={() => setIsCreateDialogOpen(false)}
+        isLoading={createMutation.isPending}
+        submitLabel="Create"
+      >
+        <AvailabilityForm
+          ref={createFormRef}
+          onSubmit={handleCreateSubmit}
+          isLoading={createMutation.isPending}
+        />
+      </FormDialog>
+
+      {/* Edit Dialog */}
+      <FormDialog
+        open={isEditDialogOpen}
+        onOpenChange={setIsEditDialogOpen}
+        title="Edit Availability Slot"
+        description="Update this availability window"
+        onSubmit={async () => {
+          await editFormRef.current?.submit();
+        }}
+        onCancel={() => {
+          setIsEditDialogOpen(false);
+          setSelected(null);
+        }}
+        isLoading={updateMutation.isPending}
+        submitLabel="Update"
+      >
+        <AvailabilityForm
+          ref={editFormRef}
+          initialData={selected || undefined}
+          onSubmit={handleEditSubmit}
+          isLoading={updateMutation.isPending}
+        />
+      </FormDialog>
+
+      {/* Delete Dialog */}
+      <DeleteDialog
+        open={isDeleteDialogOpen}
+        onOpenChange={setIsDeleteDialogOpen}
+        title="Delete Availability Slot"
+        description="Are you sure you want to delete {name}? This action cannot be undone."
+        itemName={getSlotLabel(selected)}
+        onConfirm={handleDeleteConfirm}
+        onCancel={() => {
+          setIsDeleteDialogOpen(false);
+          setSelected(null);
+        }}
+        isLoading={deleteMutation.isPending}
+      />
+    </div>
+  );
+}

--- a/frontend/app/availability/availability-form.tsx
+++ b/frontend/app/availability/availability-form.tsx
@@ -1,0 +1,254 @@
+'use client';
+
+import * as React from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { type Availability, type CreateAvailabilityDto } from '@/lib/api/availability';
+
+const DAY_OPTIONS = [
+  { value: 0, label: 'Sunday' },
+  { value: 1, label: 'Monday' },
+  { value: 2, label: 'Tuesday' },
+  { value: 3, label: 'Wednesday' },
+  { value: 4, label: 'Thursday' },
+  { value: 5, label: 'Friday' },
+  { value: 6, label: 'Saturday' },
+];
+
+const timeRegex = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+const availabilityFormSchema = z
+  .object({
+    isRecurring: z.boolean().default(true),
+    dayOfWeek: z.number().min(0).max(6).optional(),
+    specificDate: z.string().optional(),
+    startTime: z
+      .string()
+      .min(1, 'Start time is required')
+      .regex(timeRegex, 'Start time must be in HH:mm format'),
+    endTime: z
+      .string()
+      .min(1, 'End time is required')
+      .regex(timeRegex, 'End time must be in HH:mm format'),
+    effectiveFrom: z.string().optional(),
+    effectiveUntil: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.isRecurring) {
+      if (data.dayOfWeek === undefined || data.dayOfWeek === null) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Day of week is required for recurring slots',
+          path: ['dayOfWeek'],
+        });
+      }
+    } else {
+      if (!data.specificDate) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Specific date is required for one-off slots',
+          path: ['specificDate'],
+        });
+      }
+    }
+  });
+
+type AvailabilityFormData = z.infer<typeof availabilityFormSchema>;
+
+interface AvailabilityFormProps {
+  initialData?: Availability;
+  onSubmit: (data: CreateAvailabilityDto) => void | Promise<void>;
+  isLoading?: boolean;
+}
+
+export interface AvailabilityFormRef {
+  submit: () => Promise<void>;
+}
+
+export const AvailabilityForm = React.forwardRef<AvailabilityFormRef, AvailabilityFormProps>(
+  ({ initialData, onSubmit, isLoading = false }, ref) => {
+    const form = useForm<AvailabilityFormData>({
+      resolver: zodResolver(availabilityFormSchema),
+      defaultValues: {
+        isRecurring: initialData?.isRecurring ?? true,
+        dayOfWeek: initialData?.dayOfWeek ?? undefined,
+        specificDate: initialData?.specificDate ?? '',
+        startTime: initialData?.startTime ?? '',
+        endTime: initialData?.endTime ?? '',
+        effectiveFrom: initialData?.effectiveFrom ?? '',
+        effectiveUntil: initialData?.effectiveUntil ?? '',
+      },
+    });
+
+    const isRecurring = form.watch('isRecurring');
+
+    const handleSubmit = form.handleSubmit(async (data) => {
+      const submitData: CreateAvailabilityDto = {
+        startTime: data.startTime,
+        endTime: data.endTime,
+        isRecurring: data.isRecurring,
+        dayOfWeek: data.isRecurring ? data.dayOfWeek : undefined,
+        specificDate: !data.isRecurring ? data.specificDate || undefined : undefined,
+        effectiveFrom: data.effectiveFrom || undefined,
+        effectiveUntil: data.effectiveUntil || undefined,
+      };
+      await onSubmit(submitData);
+    });
+
+    React.useImperativeHandle(ref, () => ({
+      submit: async () => {
+        await handleSubmit();
+      },
+    }));
+
+    return (
+      <Form {...form}>
+        <div className="space-y-4">
+          {/* Recurring toggle */}
+          <FormField
+            control={form.control}
+            name="isRecurring"
+            render={({ field }) => (
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                <FormControl>
+                  <input
+                    type="checkbox"
+                    checked={field.value}
+                    onChange={field.onChange}
+                    className="h-4 w-4 rounded border-gray-300 text-primary focus:ring-primary disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={isLoading}
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Recurring weekly slot</FormLabel>
+                  <p className="text-sm text-muted-foreground">
+                    Enable for a repeating weekly schedule; disable for a one-off date
+                  </p>
+                </div>
+              </FormItem>
+            )}
+          />
+
+          {/* Conditional: day of week OR specific date */}
+          {isRecurring ? (
+            <FormField
+              control={form.control}
+              name="dayOfWeek"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Day of Week *</FormLabel>
+                  <FormControl>
+                    <select
+                      className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
+                      value={field.value ?? ''}
+                      onChange={(e) =>
+                        field.onChange(e.target.value !== '' ? Number(e.target.value) : undefined)
+                      }
+                      disabled={isLoading}
+                    >
+                      <option value="">Select a day</option>
+                      {DAY_OPTIONS.map((day) => (
+                        <option key={day.value} value={day.value}>
+                          {day.label}
+                        </option>
+                      ))}
+                    </select>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : (
+            <FormField
+              control={form.control}
+              name="specificDate"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Specific Date *</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="date" disabled={isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          )}
+
+          {/* Start / End time */}
+          <div className="grid grid-cols-2 gap-4">
+            <FormField
+              control={form.control}
+              name="startTime"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Start Time *</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="time" disabled={isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="endTime"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>End Time *</FormLabel>
+                  <FormControl>
+                    <Input {...field} type="time" disabled={isLoading} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Effective from / until (recurring only) */}
+          {isRecurring && (
+            <div className="grid grid-cols-2 gap-4">
+              <FormField
+                control={form.control}
+                name="effectiveFrom"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Effective From</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="date" disabled={isLoading} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="effectiveUntil"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Effective Until</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="date" disabled={isLoading} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+          )}
+        </div>
+      </Form>
+    );
+  },
+);
+
+AvailabilityForm.displayName = 'AvailabilityForm';

--- a/frontend/app/availability/page.tsx
+++ b/frontend/app/availability/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { getServerUser } from '@/lib/auth-server';
+import { AvailabilityContent } from './availability-content';
+
+export default async function AvailabilityPage() {
+  const user = await getServerUser();
+
+  if (!user) {
+    redirect('/login?invalid_token=true');
+  }
+
+  return <AvailabilityContent />;
+}

--- a/frontend/lib/api/availability.ts
+++ b/frontend/lib/api/availability.ts
@@ -1,0 +1,70 @@
+import apiClient from '../api-client';
+
+export interface Availability {
+  id: string;
+  tutorId: string;
+  dayOfWeek: number | null;
+  startTime: string;
+  endTime: string;
+  isRecurring: boolean;
+  specificDate: string | null;
+  effectiveFrom: string | null;
+  effectiveUntil: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateAvailabilityDto {
+  tutorId?: string;
+  dayOfWeek?: number;
+  startTime: string;
+  endTime: string;
+  isRecurring?: boolean;
+  specificDate?: string;
+  effectiveFrom?: string;
+  effectiveUntil?: string;
+}
+
+export interface UpdateAvailabilityDto {
+  tutorId?: string;
+  dayOfWeek?: number;
+  startTime?: string;
+  endTime?: string;
+  isRecurring?: boolean;
+  specificDate?: string;
+  effectiveFrom?: string;
+  effectiveUntil?: string;
+}
+
+export interface SearchAvailabilityQuery {
+  tutorId?: string;
+  dayOfWeek?: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+export const availabilityApi = {
+  getAll: async (query?: SearchAvailabilityQuery): Promise<Availability[]> => {
+    const response = await apiClient.get<Availability[]>('/availability', { params: query });
+    return response.data;
+  },
+
+  getById: async (id: string): Promise<Availability> => {
+    const response = await apiClient.get<Availability>(`/availability/${id}`);
+    return response.data;
+  },
+
+  create: async (data: CreateAvailabilityDto): Promise<Availability> => {
+    const response = await apiClient.post<Availability>('/availability', data);
+    return response.data;
+  },
+
+  update: async (id: string, data: UpdateAvailabilityDto): Promise<Availability> => {
+    const response = await apiClient.patch<Availability>(`/availability/${id}`, data);
+    return response.data;
+  },
+
+  delete: async (id: string): Promise<void> => {
+    await apiClient.delete(`/availability/${id}`);
+  },
+};


### PR DESCRIPTION
Closes #131

## Summary

- Full backend availability API (`GET`, `POST`, `PATCH`, `DELETE /availability`)
- Tutor-scoped access control (tutors see/manage only their own slots; admins see all)
- Business rule enforcement: `isRecurring=true` requires `dayOfWeek`; `isRecurring=false` requires `specificDate`
- Frontend page at `/availability` with full CRUD (DataTable + FormDialog + DeleteDialog)
- `AvailabilityForm` with `isRecurring` toggle that conditionally shows day-of-week select vs date picker

## Test plan

- [ ] Tutor can create a recurring slot (dayOfWeek required, specificDate rejected)
- [ ] Tutor can create a one-off slot (specificDate required, dayOfWeek rejected)
- [ ] Tutor cannot see/edit/delete another tutor's slots (returns 404)
- [ ] Admin can create a slot for any tutor by passing `tutorId`
- [ ] Admin can list all tutors' slots; filter by `tutorId`, `dayOfWeek`, `startDate`/`endDate`
- [ ] Frontend `/availability` page loads, creates, edits, and deletes slots correctly
- [ ] `isRecurring` toggle in form shows correct conditional fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)